### PR TITLE
Regenerate icon/button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diceware.org",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "diceware.org",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diceware.org",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.5.2",

--- a/src/components/Phrases.tsx
+++ b/src/components/Phrases.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { generateNPhrases } from '../diceware';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCopy } from '@fortawesome/free-solid-svg-icons';
+import { faCopy, faRefresh } from '@fortawesome/free-solid-svg-icons';
 import { Tooltip } from '@mantine/core';
 
 interface PhrasesProps {
@@ -10,6 +10,7 @@ interface PhrasesProps {
 }
 
 const Phrases = React.memo(({ wordCount, phraseCount }: PhrasesProps) => {
+  const [refreshCount, setRefreshCount] = useState(0);
   const [tooltipOpenedIds, setTooltipOpenedIds] = useState<boolean[]>(Array(phraseCount).fill(false));
 
   useEffect(() => {
@@ -30,14 +31,15 @@ const Phrases = React.memo(({ wordCount, phraseCount }: PhrasesProps) => {
 
   const generatedPhrases = useMemo(() => {
     return generateNPhrases(phraseCount, wordCount);
-  }, [phraseCount, wordCount]);
+  }, [phraseCount, wordCount, refreshCount]);
 
   if ( !wordCount || !phraseCount ) return;
 
   return (
     <div>
       <h2 className="phrasesHeader">
-        Here { phraseCount > 1 ? 'are' : 'is' } { phraseCount } phrase{ phraseCount > 1 ? 's' : ''} with { wordCount } word{ wordCount > 1 ? 's' : ''}{ phraseCount > 1 ? ' each' : ''}:
+        Here { phraseCount > 1 ? 'are' : 'is' } { phraseCount } phrase{ phraseCount > 1 ? 's' : ''} with { wordCount } word{ wordCount > 1 ? 's' : ''}{ phraseCount > 1 ? ' each' : ''}: 
+        <span className="refresh-icon" onClick={() => setRefreshCount(count => count + 1)}><FontAwesomeIcon icon={faRefresh} /></span>
       </h2>
       
       <div>

--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,15 @@ a:visited {
   cursor: pointer;
 }
 
+.refresh-icon {
+  margin-left: 0.36em;
+  color: #50504d;
+}
+
+.refresh-icon :hover {
+  color: rgb(171, 227, 241);
+}
+
 footer {
   color:  #999;
   margin-left: 2rem;


### PR DESCRIPTION
An icon to regenerate more phrases with the same word and number counts, so the user doesn't have to resort to using the sliders if there are no options they like in the currently generated set.


![diceware_regen_demo2](https://github.com/rotarydialer/diceware.org/assets/15839926/a718662b-a299-409d-b2cb-73190b5a99c4)
